### PR TITLE
feat: 전체 유저 벌금 랭킹 조회 API 구현

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -13,6 +13,7 @@ var testRouter = require("./routes/test");
 const myStudyInfoRouter = require("./routes/myStudyInfo");
 var studyRoomRouter = require("./routes/studyRoomRoutes");
 var signUpRouter = require("./routes/signUp");
+var fineRankingRouter = require("./routes/fineRanking");
 
 const cors = require("cors");
 
@@ -38,7 +39,7 @@ app.use("/study-rooms", studyRoomRouter);
 app.use("/test", testRouter);
 app.use("/signUp", signUpRouter);
 app.use("/myStudyInfo", myStudyInfoRouter);
-
+app.use("/fine-ranking", fineRankingRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/backend/controller/fineRankingController.js
+++ b/backend/controller/fineRankingController.js
@@ -1,0 +1,17 @@
+const fineRankingService = require("../service/fineRankingService");
+const STATUS = require("../common/status");
+
+exports.getFineRanking = async (req, res) => {
+  console.log("🔥 컨트롤러 도착!!! 띠용!");
+
+  try {
+    const ranking = await fineRankingService.calculateFineRanking();
+
+    res.status(200).json(ranking);
+  } catch (error) {
+    console.error("벌금 랭킹 에러:", error);
+    res
+      .status(500)
+      .json({ status: STATUS.SERVER_ERROR, message: "서버 에러 발생" });
+  }
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-s3": "^3.837.0",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
+        "dayjs": "^1.11.13",
         "debug": "~2.6.9",
         "dotenv": "^16.5.0",
         "ejs": "~2.6.1",
@@ -3470,6 +3471,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "@aws-sdk/client-s3": "^3.837.0",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
+    "dayjs": "^1.11.13",
     "debug": "~2.6.9",
     "dotenv": "^16.5.0",
     "ejs": "~2.6.1",

--- a/backend/routes/fineRanking.js
+++ b/backend/routes/fineRanking.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const fineRankingController = require("../controller/fineRankingController");
+
+router.get("/", fineRankingController.getFineRanking);
+
+module.exports = router;

--- a/backend/service/fineRankingService.js
+++ b/backend/service/fineRankingService.js
@@ -1,0 +1,70 @@
+import pool from "../config/db.js";
+import dayjs from "dayjs";
+
+export async function calculateFineRanking() {
+  console.log("🚀 [Service] fine-ranking 계산 시작");
+
+  try {
+    // 모든 user들 가져오기
+    const users = await pool.execute(`
+      SELECT id, username, email, profile_image FROM USERS
+    `);
+
+    const result = [];
+
+    // user들에 대한 참여 스터디들 가져오기
+    for (const user of users) {
+      console.log("현재 유저 id");
+      console.log(user.id);
+
+      const studies = await pool.execute(
+        `SELECT study_id FROM STUDY_MEMBERS WHERE user_id = ?`,
+        [user.id]
+      );
+      console.log("참여한 스터디들 ");
+      let total_fine = 0;
+
+      for (const study of studies) {
+        console.log("스터디: ", study.study_id);
+
+        const study_info = await pool.execute(
+          `SELECT penalty_amount, start_date, end_date, weekly_required_count  FROM STUDY_ROOMS WHERE id = ?`,
+          [study.study_id]
+        );
+
+        // console.log("스터디 정보: ", study_info[0]);
+        const today = dayjs();
+        const endDate = dayjs(study_info[0].end_date);
+        const lastDate = today.isBefore(endDate) ? today : endDate;
+        const startDate = dayjs(study_info[0].start_date);
+
+        const weeksPassed = Math.floor(lastDate.diff(startDate, "day") / 7);
+        console.log("🗓️ 주 수:", weeksPassed);
+
+        // 인증한 주차 수 계산 (유저 - 스터디)
+        const countPassWeek = await pool.execute(
+          `SELECT count(*) as count FROM WEEKLY_STUDIES WHERE study_id = ? and user_id = ? `,
+          [study.study_id, user.id]
+        );
+        const certifiedWeeks = Number(countPassWeek[0].count);
+        console.log("인증완료 주차 수 :", certifiedWeeks);
+
+        total_fine +=
+          (weeksPassed - certifiedWeeks) * study_info[0].penalty_amount;
+      }
+      console.log("유저 별 총 벌금 :", total_fine);
+
+      result.push({
+        username: user.username,
+        email: user.email,
+        profileImage: user.profile_image,
+        totalPenalty: total_fine,
+      });
+    }
+    result.sort((a, b) => b.totalPenalty - a.totalPenalty);
+    return result;
+  } catch (err) {
+    console.error("안된다 안돼애~~~", err);
+    throw err;
+  }
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 // app/layout.tsx
+import "bootstrap/dist/css/bootstrap.min.css";
 import "./globals.css";
 import AppNavbar from "@/layouts/MyNavbar/MyNavbar"; // ✅ 클라이언트 컴포넌트를 import
 import "../assets/styles/font.css"; // 또는 ./assets/styles/font.css
@@ -28,8 +29,7 @@ export default function RootLayout({
             backgroundSize: "contain", // ✅ 이미지 크기 그대로 표시
             position: "relative",
             zIndex: 0,
-          }}
-        >
+          }}>
           <AppNavbar /> {/* 클라 컴포넌트 OK */}
           {children}
         </div>


### PR DESCRIPTION
## 🔍 주요 변경 사항

- 전체 유저의 벌금을 계산하는 `벌금 랭킹 API` (`GET /fine-ranking`) 구현
- 참여 중인 스터디의 주차 수 및 주당 인증 횟수 기반으로 총 인증 필요 횟수 계산
- 실제 인증 횟수를 조회하여 누락 횟수 × 벌금 단가로 합산
- 유저 정보(username, email, profileImage)와 누적 벌금을 함께 반환
- 벌금 총액 기준으로 내림차순 정렬

## ✅ 응답 예시

```json
[
  {
    "username": "코딩짱짱",
    "email": "code@example.com",
    "profileImage": "https://example.com/img.png",
    "totalPenalty": 3000
  },
  ...
]